### PR TITLE
Number of lines in the doc was duplicated (with empty lines)

### DIFF
--- a/doc/doc.go
+++ b/doc/doc.go
@@ -120,7 +120,7 @@ func Create(cfTemplate []byte) *Doc {
 	}
 
 	// Create Doc Outputs
-	keys = make([]string, len(cfOut.Outputs))
+	keys = make([]string, 0)
 	for k := range cfOut.Outputs {
 		keys = append(keys, k)
 	}


### PR DESCRIPTION
I'd like to use cf-doc. But I need the entries sorted alphabetically. That is implemented in branch dev, but not in the tagged version v0.0.1.
Unfortunately the dev branch code inserts a number of empty lines before the content, so the result looks like this:
```md
## Parameters

| Name | Description | Type | Default | Allowed Values |
|------|-------------|:----:|:-------:|:---------------|
|  |  |  |  |  |
|  |  |  |  |  |
|  |  |  |  |  |
|  |  |  |  |  |
|  |  |  |  |  |
|  |  |  |  |  |
|  |  |  |  |  |
|  |  |  |  |  |
|  |  |  |  |  |
|  |  |  |  |  |
|  |  |  |  |  |
|  |  |  |  |  |
|  |  |  |  |  |
|  |  |  |  |  |
|  |  |  |  |  |
|  |  |  |  |  |
|  |  |  |  |  |
|  |  |  |  |  |
|  |  |  |  |  |
|  |  |  |  |  |
| AlarmMetric | One of following values: [CPUUtilization, disk_used_percent] | String | CPUUtilization |  |
...
```

creating keys with zero entries fixes the issue.
```go
keys := make([]string, 0)
```